### PR TITLE
Fix merge conflicts with CLJS files PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ from a Clojure project directory. This outputs a file `ns-dep-graph.png` showing
 the internal namespace dependencies of the project's `.clj` sources.
 Dependencies on external namespaces, say `clojure.java.io`, are not shown.
 
+You can also pass an optional platform argument to generate a graph for ClojureScript
+
+    lein ns-dep-graph :cljs # or
+    lein ns-dep-graph :clj
+
 ## Examples
 
 Below is the namespace dependency graph obtained for

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
-(defproject lein-ns-dep-graph "0.1.0-SNAPSHOT"
+(defproject lein-ns-dep-graph "0.2.0-SNAPSHOT"
   :description "Show namespace dependencies of project sources as a graph."
   :url "https://github.com/hilverd/lein-ns-dep-graph"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :eval-in-leiningen true
-  :dependencies [[org.clojure/tools.namespace "0.2.3"]
+  :dependencies [[org.clojure/tools.namespace "0.3.0-alpha2"]
                  [rhizome "0.1.8"]])

--- a/src/leiningen/ns_dep_graph.clj
+++ b/src/leiningen/ns_dep_graph.clj
@@ -4,19 +4,37 @@
             [clojure.tools.namespace.file :as ns-file]
             [clojure.tools.namespace.track :as ns-track]
             [clojure.tools.namespace.find :as ns-find]
+            [clojure.tools.namespace.parse :as parse]
             [clojure.tools.namespace.dependency :as ns-dep]
-            [rhizome.viz :as viz]))
+            [rhizome.viz :as viz])
+  (:import (java.io PushbackReader)))
+
+(defn read-file-ns-decl
+  "Attempts to read a (ns ...) declaration from file, and returns the
+  unevaluated form. Returns nil if read fails due to invalid syntax or
+  if a ns declaration cannot be found. read-opts is passed through to
+  tools.reader/read."
+  ([file]
+   (read-file-ns-decl file nil))
+  ([file read-opts]
+   (with-open [rdr (PushbackReader. (io/reader file))]
+     (try (parse/read-ns-decl rdr read-opts)
+          (catch Exception e (println "Exception while parsing ns decl:" e))))))
 
 (defn ns-dep-graph
   "Create a namespace dependency graph and save it as ns-dep-graph.png."
-  [project & args]
-  (let [source-files (apply set/union
-                            (map (comp ns-find/find-clojure-sources-in-dir
+  [project & [platform-kw]]
+  (let [platform (case (read-string platform-kw)
+                   :clj ns-find/clj
+                   :cljs ns-find/cljs
+                   ns-find/clj)
+        source-files (apply set/union
+                            (map (comp #(ns-find/find-sources-in-dir % platform)
                                        io/file)
                                  (project :source-paths)))
         tracker (ns-file/add-files {} source-files)
         dep-graph (tracker ::ns-track/deps)
-        ns-names (set (map (comp second ns-file/read-file-ns-decl)
+        ns-names (set (map (comp second read-file-ns-decl)
                            source-files))
         part-of-project? (partial contains? ns-names)
         nodes (filter part-of-project? (ns-dep/nodes dep-graph))]


### PR DESCRIPTION
Hey @danielcompton,

I had a crack at fixing the conflicts with your CLJS files work and https://github.com/hilverd/lein-ns-dep-graph/pull/4, so that hopefully you can get https://github.com/hilverd/lein-ns-dep-graph/pull/2 merged.

I've tested it out on hiccup, core.async, our fairly large CLJ / CLJS / CLJC app ([BookWell](https://www.bookwell.com.au/)) and reagent, and the only one that failed was reagent, because it has a dependency on codox, which depends on tools.namespace 0.2.x.

I'm not sure if the maintainers of lein-ns-dep-graph are going to want to break backwards compatibility with any project that depends on 0.2.x, and AFAIK the only way around it would be to check for which one is on the classpath and then dynamically load based on that.
